### PR TITLE
Avoid modifying manifests unless necessary

### DIFF
--- a/src/state/actionProducers/updatePlugins.ts
+++ b/src/state/actionProducers/updatePlugins.ts
@@ -176,8 +176,13 @@ async function installManifestFile(
      * An example is periodic-notes version 1.0.0-beta.3 that uses version 0.0.17 in its manifest.
      */
     const manifestJson = JSON.parse(fileContents);
-    manifestJson.version = versionNumber;
-    await installPluginFile(pluginId, fileName, JSON.stringify(manifestJson));
+    let contents = fileContents;
+    // only update the manifest.json if changes need to be made
+    if (manifestJson.version !== versionNumber) {
+        manifestJson.version = versionNumber;
+        contents = JSON.stringify(manifestJson, null, '\t');
+    }
+    await installPluginFile(pluginId, fileName, contents);
 }
 
 async function installPluginFile(pluginId: string, fileName: string, fileContents: string) {


### PR DESCRIPTION
I humbly suggest this change to `installManifestFile` which keeps downloaded manifest contents unless it *needs* to be changed.

Currently, Obsidian Plugin Update Tracker will always parse and re-serialize the updated plugin's manifest.json. I like to version control my vault (with [obsidian-git](https://github.com/Vinzent03/obsidian-git)), so this unfortunately causes a lot of history churn in the manifest.json:

```diff
diff --git a/.obsidian/plugins/obsidian-git/manifest.json b/.obsidian/plugins/obsidian-git/manifest.json
index 34b889a9..dd6377c3 100644
--- a/.obsidian/plugins/obsidian-git/manifest.json
+++ b/.obsidian/plugins/obsidian-git/manifest.json
@@ -1,10 +1 @@
-{
-    "author": "Vinzent",
-    "authorUrl": "https://github.com/Vinzent03",
-    "id": "obsidian-git",
-    "name": "Git",
-    "description": "Integrate Git version control with automatic backup and other advanced features.",
-    "isDesktopOnly": false,
-    "fundingUrl": "https://ko-fi.com/vinzent",
-    "version": "2.28.1"
-}
+{"author":"Vinzent","authorUrl":"https://github.com/Vinzent03","id":"obsidian-git","name":"Git","description":"Integrate Git version control with automatic backup and other advanced features.","isDesktopOnly":false,"fundingUrl":"https://ko-fi.com/vinzent","version":"2.28.2"}
\ No newline at end of file
```

Instead, only rewrite the manifest if we actually need to change it (i.e. the version number in the manifest does not match the github release version).

When there *does* need to be a change to the manifest, we serialize it with indentation (hardcoded[^1] to tabs[^2]) for readability as well as (ideally) better git history. 

[^1]: Unfortunately, obsidian downloads the manifest directly from the plugin's repo without reparsing it, and the indentation varies. I hardcoded a default setting. We could instead parse the manifest contents to deduce the indentation type, but I opted to avoid the complexity, since the `manifestJson.version !== versionNumber` code path should not be commonly used anyways.

[^2]: I opted to use tabs to match the standard set by [obsidianmd/obsidian-sample-plugin](https://github.com/obsidianmd/obsidian-sample-plugin/blob/daa0cba23c36bbdd033087a1f7e6463b57b5ebf5/version-bump.mjs). 