### PR TITLE
Fix invalid label position attribute

### DIFF
--- a/src/components/DismissedPluginVersions.tsx
+++ b/src/components/DismissedPluginVersions.tsx
@@ -116,7 +116,7 @@ const DismissedPluginVersions: React.FC<DismissedPluginVersionsProps> = ({
                                         onClickUndismissVersion(row.pluginId, row.versionNumber)
                                     }
                                     aria-label="Restore"
-                                    aria-label-position-="top"
+                                    data-tooltip-position="top"
                                     className="clickable-icon"
                                 >
                                     <FontAwesomeIcon icon={faRotateLeft} size="sm" />

--- a/src/components/PluginUpdateList.tsx
+++ b/src/components/PluginUpdateList.tsx
@@ -250,7 +250,7 @@ export const PluginUpdateList: React.FC<{
                         disabled={isDisabled}
                         title={selectAllTitle}
                         aria-label={selectAllTitle}
-                        aria-label-position="top"
+                        data-tooltip-position="top"
                     />
                 </DivSelectAll>
             )}
@@ -327,7 +327,7 @@ const PluginUpdates: React.FC<{
                     {plugin.latestInstallableVersionIsBeta && (
                         <SpanBetaVersionBadge
                             aria-label="This version may be unstable"
-                            aria-label-position="top"
+                            data-tooltip-position="top"
                             className="obsidian-plugin-update-tracker-beta-version"
                         >
                             ⚠️ Beta Version
@@ -336,7 +336,7 @@ const PluginUpdates: React.FC<{
                     {!plugin.isPluginEnabled && (
                         <SpanDisabledPlugin
                             aria-label="This plugin is disabled"
-                            aria-label-position="top"
+                            data-tooltip-position="top"
                             className="obsidian-plugin-update-tracker-disabled-plugin"
                         >
                             Disabled


### PR DESCRIPTION
`aria-label-position-` is not a valid aria prop. (I assume this was inteded to be `aria-label-position`)

```stacktrace
react-dom.development.js:86
Warning: Invalid aria prop `aria-label-position-` on <span> tag. For details, see https://reactjs.org/link/invalid-aria-props
    at span
    at O2 (plugin:obsidian-plugin-update-tracker:38766:6)
    at div
    at div
    at O2 (plugin:obsidian-plugin-update-tracker:38766:6)
    at div
    at DismissedPluginVersions (plugin:obsidian-plugin-update-tracker:41337:3)
    at DismissedPluginVersionsConnected (plugin:obsidian-plugin-update-tracker:41315:3)
    at Provider (plugin:obsidian-plugin-update-tracker:34816:10)
```

It also does not induce the intended behavior of placing the tooltip above the icon.

It seems this attribute (or at least, the intended `aria-label-position`) was used in a previous version of obsidian (not sure exactly when it changed), but currently (v1.7), obsidian uses `data-tooltip-position`

from obsidian's `app.js` (v1.7.5):

```javascript
function RS(e, t) {
    var n = t || {}
      , i = n.placement
      , r = n.classes
      , o = n.delay;
    i && "bottom" !== i && e.setAttribute("data-tooltip-position", i),
    r && e.setAttribute("data-tooltip-classes", r.join(" ")),
    o && e.setAttribute("data-tooltip-delay", String(o))
}
```

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/11df18dd-9b5e-45fb-b127-5eea5c4213e0) | ![image](https://github.com/user-attachments/assets/75de236e-e6a7-4bc5-9740-f1eae520447b) |
