### PR TITLE
Improve wording and spacing in rate-limit error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-plugin-update-tracker",
-  "version": "1.5.2",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-plugin-update-tracker",
-      "version": "1.5.2",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",

--- a/src/components/PluginUpdateProgressTracker.tsx
+++ b/src/components/PluginUpdateProgressTracker.tsx
@@ -69,7 +69,7 @@ export const PluginUpdateProgressTracker: React.FC<{
     let errorInstructions = '';
     if (githubRateLimitTimestamp) {
         const time = dayjs(githubRateLimitTimestamp);
-        errorInstructions = `Your IP address has exceeded github's limit of 60 file downloads in an hour. The limit will reset in ${time.fromNow()}, but if that doesn't work then report an issue`;
+        errorInstructions = `Your IP address has exceeded github's limit of 60 file downloads in an hour. The limit will reset ${time.fromNow()}, but if that doesn't work then report an issue `;
     } else {
         errorInstructions = `Try again or report an issue `;
     }


### PR DESCRIPTION
This fixes typos like "The limit will reset in in 12 minutes". It also puts a space before the link to create an issue.

Here's a screenshot showing the changed areas:

![image](https://github.com/user-attachments/assets/e715f535-9034-42a8-9555-cf1ed1b64a9f)

Thank you for this super useful plugin!
